### PR TITLE
feat: add district-personalized bill impact analysis

### DIFF
--- a/src/app/api/bill/[billId]/district-impact/[districtId]/route.ts
+++ b/src/app/api/bill/[billId]/district-impact/[districtId]/route.ts
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2019-2025 Mark Sandford
+ * Licensed under the MIT License. See LICENSE and NOTICE files.
+ */
+
+/**
+ * District Impact API Endpoint
+ *
+ * Returns AI-generated analysis of how a specific bill impacts a congressional district.
+ * Cross-references bill summary with district-level economic and spending data.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { DistrictImpactAnalyzer } from '@/features/legislation/services/ai/district-impact-analyzer';
+import { BillSummaryCache } from '@/features/legislation/services/ai/bill-summary-cache';
+import logger from '@/lib/logging/simple-logger';
+import { InputValidator } from '@/lib/validation/input-validator';
+import type { EconomicProfile, GovernmentServicesProfile } from '@/types/district-enhancements';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ billId: string; districtId: string }> }
+): Promise<NextResponse> {
+  const startTime = Date.now();
+
+  try {
+    const { billId, districtId } = await params;
+
+    // Validate billId
+    const billIdErrors = InputValidator.validateValue(billId, {
+      required: true,
+      minLength: 5,
+      maxLength: 20,
+      pattern: /^[A-Z0-9\-\.]+$/i,
+    });
+
+    if (billIdErrors.length > 0) {
+      return NextResponse.json(
+        { error: 'Invalid bill ID', details: billIdErrors },
+        { status: 400 }
+      );
+    }
+
+    // Validate districtId (format: XX-## like CA-12, NY-7, or at-large like AK-0)
+    const districtIdErrors = InputValidator.validateValue(districtId, {
+      required: true,
+      minLength: 3,
+      maxLength: 10,
+      pattern: /^[A-Z]{2}-\d{1,2}$/i,
+    });
+
+    if (districtIdErrors.length > 0) {
+      return NextResponse.json(
+        { error: 'Invalid district ID', details: districtIdErrors },
+        { status: 400 }
+      );
+    }
+
+    const normalizedDistrictId = districtId.toUpperCase();
+
+    logger.info('District impact request received', {
+      billId,
+      districtId: normalizedDistrictId,
+      operation: 'district_impact_api',
+    });
+
+    // Fetch bill summary and district data in parallel
+    const [billSummary, economicData, spendingData] = await Promise.all([
+      fetchBillSummary(billId),
+      fetchEconomicProfile(normalizedDistrictId),
+      fetchGovernmentSpending(normalizedDistrictId),
+    ]);
+
+    if (!billSummary) {
+      return NextResponse.json(
+        {
+          error: 'Bill summary not found',
+          message: 'Unable to retrieve bill summary for impact analysis',
+        },
+        { status: 404 }
+      );
+    }
+
+    // Generate district impact analysis
+    const impact = await DistrictImpactAnalyzer.analyzeImpact(
+      billSummary.text,
+      {
+        districtId: normalizedDistrictId,
+        economic: economicData,
+        government: spendingData,
+      },
+      {
+        billId,
+        title: billSummary.title,
+        number: billSummary.number,
+      }
+    );
+
+    const responseTime = Date.now() - startTime;
+
+    logger.info('District impact analysis completed', {
+      billId,
+      districtId: normalizedDistrictId,
+      responseTime,
+      overallImpact: impact.overallImpact,
+      confidence: impact.confidence,
+      source: impact.source,
+      operation: 'district_impact_api',
+    });
+
+    return NextResponse.json(
+      {
+        impact,
+        metadata: {
+          responseTime,
+          districtId: normalizedDistrictId,
+          billId,
+          dataSources: {
+            billSummary: 'CIV.IQ AI Summary',
+            economic: 'Bureau of Labor Statistics, FCC',
+            spending: 'USASpending.gov',
+          },
+        },
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+        },
+      }
+    );
+  } catch (error) {
+    const responseTime = Date.now() - startTime;
+    const resolvedParams = await params;
+
+    logger.error('District impact analysis failed', error as Error, {
+      billId: resolvedParams.billId,
+      districtId: resolvedParams.districtId,
+      responseTime,
+      operation: 'district_impact_api',
+    });
+
+    return NextResponse.json(
+      {
+        error: 'Impact analysis failed',
+        message: 'Unable to generate district impact analysis at this time',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Fetch bill summary from cache or summary API
+ */
+async function fetchBillSummary(
+  billId: string
+): Promise<{ text: string; title: string; number: string } | null> {
+  try {
+    // Try cache first
+    const cached = await BillSummaryCache.getSummary(billId);
+    if (cached) {
+      return {
+        text: cached.summary || cached.whatItDoes || '',
+        title: cached.title,
+        number: billId,
+      };
+    }
+
+    // Fallback: fetch from summary API
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const response = await fetch(`${baseUrl}/api/bill/${billId}/summary`, {
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json();
+    if (data.summary) {
+      return {
+        text: data.summary.summary || data.summary.whatItDoes || '',
+        title: data.summary.title || '',
+        number: billId,
+      };
+    }
+
+    return null;
+  } catch (error) {
+    logger.warn('Failed to fetch bill summary for impact analysis', {
+      billId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    return null;
+  }
+}
+
+/**
+ * Fetch district economic profile from existing API
+ */
+async function fetchEconomicProfile(districtId: string): Promise<EconomicProfile> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const response = await fetch(`${baseUrl}/api/districts/${districtId}/economic-profile`, {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.economic) {
+        return data.economic;
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed to fetch economic profile', {
+      districtId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+
+  // Return zero values on failure
+  return {
+    employment: {
+      unemploymentRate: 0,
+      laborForceParticipation: 0,
+      jobGrowthRate: 0,
+      majorIndustries: [],
+      averageWage: 0,
+    },
+    infrastructure: {
+      bridgeConditionRating: 0,
+      highwayFunding: 0,
+      broadbandAvailability: 0,
+      publicTransitAccessibility: 0,
+    },
+    connectivity: {
+      fiberAvailability: 0,
+      averageDownloadSpeed: 0,
+      averageUploadSpeed: 0,
+      digitalDivideIndex: 0,
+    },
+  };
+}
+
+/**
+ * Fetch district government spending data from existing API
+ */
+async function fetchGovernmentSpending(districtId: string): Promise<GovernmentServicesProfile> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const response = await fetch(`${baseUrl}/api/districts/${districtId}/government-spending`, {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.government) {
+        return data.government;
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed to fetch government spending', {
+      districtId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+
+  // Return zero values on failure
+  return {
+    federalInvestment: {
+      totalAnnualSpending: 0,
+      contractsAndGrants: 0,
+      majorProjects: [],
+      infrastructureInvestment: 0,
+    },
+    socialServices: {
+      snapBeneficiaries: 0,
+      medicaidEnrollment: 0,
+      housingAssistanceUnits: 0,
+      veteransServices: 0,
+    },
+    representation: {
+      billsAffectingDistrict: [],
+      federalFacilities: [],
+      appropriationsSecured: 0,
+    },
+  };
+}

--- a/src/app/bill/[billId]/ClientBillContent.tsx
+++ b/src/app/bill/[billId]/ClientBillContent.tsx
@@ -26,6 +26,14 @@ import {
   BillSummaryError,
 } from '@/features/legislation/components/BillSummary';
 import type { BillSummary as BillSummaryType } from '@/features/legislation/services/ai/bill-summarizer';
+import {
+  DistrictImpactDisplay,
+  DistrictImpactSkeleton,
+  DistrictImpactError,
+} from '@/features/legislation/components/DistrictImpact';
+import { DistrictSelector } from '@/features/legislation/components/DistrictSelector';
+import type { DistrictImpact as DistrictImpactType } from '@/types/district-impact';
+import { useSearchParams } from 'next/navigation';
 
 interface ClientBillContentProps {
   billId: string;
@@ -38,6 +46,11 @@ export function ClientBillContent({ billId }: ClientBillContentProps) {
   const [aiSummary, setAiSummary] = useState<BillSummaryType | null>(null);
   const [aiSummaryLoading, setAiSummaryLoading] = useState(false);
   const [aiSummaryError, setAiSummaryError] = useState<string | null>(null);
+  const [district, setDistrict] = useState<string | null>(null);
+  const [districtImpact, setDistrictImpact] = useState<DistrictImpactType | null>(null);
+  const [districtImpactLoading, setDistrictImpactLoading] = useState(false);
+  const [districtImpactError, setDistrictImpactError] = useState<string | null>(null);
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     async function fetchBill() {
@@ -71,6 +84,51 @@ export function ClientBillContent({ billId }: ClientBillContentProps) {
 
     fetchBill();
   }, [billId]);
+
+  // Initialize district from URL param or localStorage
+  useEffect(() => {
+    const urlDistrict = searchParams.get('district');
+    if (urlDistrict && /^[A-Z]{2}-\d{1,2}$/i.test(urlDistrict)) {
+      setDistrict(urlDistrict.toUpperCase());
+      return;
+    }
+    try {
+      const stored = localStorage.getItem('civiq-district');
+      if (stored && /^[A-Z]{2}-\d{1,2}$/i.test(stored)) {
+        setDistrict(stored.toUpperCase());
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, [searchParams]);
+
+  // Fetch district impact when district is set and bill is loaded
+  useEffect(() => {
+    if (!bill || !district) return;
+    let cancelled = false;
+
+    async function fetchDistrictImpact() {
+      try {
+        setDistrictImpactLoading(true);
+        setDistrictImpactError(null);
+        const response = await fetch(`/api/bill/${billId}/district-impact/${district}`);
+        if (!response.ok) return;
+        const data = await response.json();
+        if (!cancelled && data.impact) {
+          setDistrictImpact(data.impact);
+        }
+      } catch {
+        if (!cancelled) setDistrictImpactError('District impact analysis unavailable');
+      } finally {
+        if (!cancelled) setDistrictImpactLoading(false);
+      }
+    }
+
+    fetchDistrictImpact();
+    return () => {
+      cancelled = true;
+    };
+  }, [bill, billId, district]);
 
   useEffect(() => {
     if (!bill) return;
@@ -239,6 +297,33 @@ export function ClientBillContent({ billId }: ClientBillContentProps) {
           {aiSummaryLoading && <BillSummarySkeleton />}
           {aiSummaryError && !aiSummaryLoading && <BillSummaryError error={aiSummaryError} />}
           {aiSummary && !aiSummaryLoading && <BillSummaryDisplay summary={aiSummary} />}
+
+          {/* District Impact Analysis */}
+          <DistrictSelector
+            currentDistrict={district}
+            onDistrictChange={newDistrict => {
+              setDistrict(newDistrict);
+              setDistrictImpact(null);
+              setDistrictImpactError(null);
+            }}
+          />
+          {district && districtImpactLoading && <DistrictImpactSkeleton />}
+          {district && districtImpactError && !districtImpactLoading && (
+            <DistrictImpactError
+              error={districtImpactError}
+              onRetry={() => {
+                setDistrictImpactError(null);
+                setDistrictImpact(null);
+                // Trigger re-fetch by toggling district
+                const d = district;
+                setDistrict(null);
+                setTimeout(() => setDistrict(d), 0);
+              }}
+            />
+          )}
+          {district && districtImpact && !districtImpactLoading && (
+            <DistrictImpactDisplay impact={districtImpact} />
+          )}
 
           {/* Policy Area & Subjects */}
           {(bill.policyArea || (bill.subjects && bill.subjects.length > 0)) && (

--- a/src/features/legislation/components/DistrictImpact.tsx
+++ b/src/features/legislation/components/DistrictImpact.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+/**
+ * Copyright (c) 2019-2025 Mark Sandford
+ * Licensed under the MIT License. See LICENSE and NOTICE files.
+ */
+
+/**
+ * District Impact Component
+ *
+ * Displays AI-generated analysis of how a bill impacts a specific congressional district.
+ * Mirrors the BillSummary component pattern with expandable sections.
+ */
+
+import React, { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  MapPin,
+  AlertCircle,
+  Target,
+  Users,
+  TrendingUp,
+  Wifi,
+  BarChart3,
+} from 'lucide-react';
+import type { DistrictImpact as DistrictImpactType } from '@/types/district-impact';
+
+interface DistrictImpactProps {
+  impact: DistrictImpactType;
+  className?: string;
+}
+
+const IMPACT_COLORS: Record<string, string> = {
+  High: 'text-red-700 bg-red-50 border-red-200',
+  Medium: 'text-yellow-700 bg-yellow-50 border-yellow-200',
+  Low: 'text-green-700 bg-green-50 border-green-200',
+  Uncertain: 'text-gray-700 bg-gray-50 border-gray-200',
+};
+
+export function DistrictImpactDisplay({ impact, className = '' }: DistrictImpactProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const getConfidenceColor = (confidence: number) => {
+    if (confidence >= 0.8) return 'text-green-600';
+    if (confidence >= 0.6) return 'text-yellow-600';
+    return 'text-red-600';
+  };
+
+  const formatDistrictLabel = (districtId: string) => {
+    const parts = districtId.split('-');
+    if (parts.length === 2) {
+      return `${parts[0]}-${parts[1]}`;
+    }
+    return districtId;
+  };
+
+  return (
+    <div className={`bg-white border-2 border-black ${className}`}>
+      {/* Header */}
+      <div className="p-4 border-b border-gray-100">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-2">
+              <MapPin className="h-5 w-5 text-civiq-blue" />
+              <span className="text-sm font-medium text-civiq-blue">
+                Impact on {formatDistrictLabel(impact.districtId)}
+              </span>
+              <span
+                className={`px-2 py-1 text-xs font-medium border ${IMPACT_COLORS[impact.overallImpact] || IMPACT_COLORS.Uncertain}`}
+              >
+                {impact.overallImpact} Impact
+              </span>
+              <span className={`text-xs ${getConfidenceColor(impact.confidence)}`}>
+                <Target className="h-3 w-3 inline mr-1" />
+                {Math.round(impact.confidence * 100)}%
+              </span>
+            </div>
+          </div>
+
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="p-2 hover:bg-white border-2 border-gray-300 transition-colors"
+            aria-label={isExpanded ? 'Collapse impact analysis' : 'Expand impact analysis'}
+          >
+            {isExpanded ? (
+              <ChevronUp className="h-5 w-5 text-gray-600" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-gray-600" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Summary - Always Visible */}
+      <div className="p-4">
+        <p className="text-gray-700 leading-relaxed">{impact.summary}</p>
+      </div>
+
+      {/* Expandable Detail Sections */}
+      {isExpanded && (
+        <div className="border-t border-gray-100">
+          {/* Economic Impact */}
+          {impact.economicImpact && (
+            <div className="p-4 border-b border-gray-100">
+              <h4 className="text-sm font-medium text-gray-900 mb-2 flex items-center gap-2">
+                <TrendingUp className="h-4 w-4 text-civiq-blue" />
+                Economic Impact
+              </h4>
+              <p className="text-gray-700 text-sm leading-relaxed">{impact.economicImpact}</p>
+            </div>
+          )}
+
+          {/* Infrastructure Impact */}
+          {impact.infrastructureImpact && (
+            <div className="p-4 border-b border-gray-100">
+              <h4 className="text-sm font-medium text-gray-900 mb-2 flex items-center gap-2">
+                <Wifi className="h-4 w-4 text-civiq-blue" />
+                Infrastructure Impact
+              </h4>
+              <p className="text-gray-700 text-sm leading-relaxed">{impact.infrastructureImpact}</p>
+            </div>
+          )}
+
+          {/* Affected Groups */}
+          {impact.affectedGroups.length > 0 && (
+            <div className="p-4 border-b border-gray-100">
+              <h4 className="text-sm font-medium text-gray-900 mb-3 flex items-center gap-2">
+                <Users className="h-4 w-4 text-civiq-blue" />
+                Who&apos;s Affected
+              </h4>
+              <div className="space-y-3">
+                {impact.affectedGroups.map((group, index) => (
+                  <div key={index} className="p-3 bg-gray-50 border border-gray-200">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm font-medium text-gray-900">{group.group}</span>
+                      {group.scale && <span className="text-xs text-gray-500">{group.scale}</span>}
+                    </div>
+                    <p className="text-sm text-gray-600">{group.impact}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* District Data */}
+          {impact.relevantDistrictData.length > 0 && (
+            <div className="p-4">
+              <h4 className="text-sm font-medium text-gray-900 mb-3 flex items-center gap-2">
+                <BarChart3 className="h-4 w-4 text-civiq-blue" />
+                District Data
+              </h4>
+              <div className="space-y-2">
+                {impact.relevantDistrictData.map((data, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center justify-between p-3 bg-gray-50 border border-gray-200"
+                  >
+                    <div>
+                      <span className="text-sm font-medium text-gray-900">{data.metric}</span>
+                      <p className="text-xs text-gray-500">{data.context}</p>
+                    </div>
+                    <span className="text-sm font-medium text-gray-700">{data.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="px-4 py-3 bg-white border-t border-gray-100">
+        <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-3 w-3" />
+            <span>
+              {impact.source === 'ai-generated'
+                ? 'AI-generated analysis'
+                : 'Data-only analysis (AI unavailable)'}{' '}
+              • District data from BLS, FCC, USASpending.gov
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface DistrictImpactSkeletonProps {
+  className?: string;
+}
+
+export function DistrictImpactSkeleton({ className = '' }: DistrictImpactSkeletonProps) {
+  return (
+    <div className={`bg-white border-2 border-black animate-pulse ${className}`}>
+      <div className="p-4 border-b border-gray-100">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="h-5 w-5 bg-gray-300"></div>
+          <div className="h-4 w-32 bg-gray-300"></div>
+          <div className="h-6 w-24 bg-gray-300"></div>
+        </div>
+      </div>
+      <div className="p-4">
+        <div className="space-y-2">
+          <div className="h-4 w-full bg-gray-300"></div>
+          <div className="h-4 w-4/5 bg-gray-300"></div>
+          <div className="h-4 w-3/5 bg-gray-300"></div>
+        </div>
+      </div>
+      <div className="px-4 py-3 bg-white border-t border-gray-100">
+        <div className="h-3 w-1/2 bg-gray-300"></div>
+      </div>
+    </div>
+  );
+}
+
+interface DistrictImpactErrorProps {
+  error: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function DistrictImpactError({ error, onRetry, className = '' }: DistrictImpactErrorProps) {
+  return (
+    <div className={`bg-white border-2 border-black ${className}`}>
+      <div className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <AlertCircle className="h-5 w-5 text-red-600" />
+          <span className="text-sm font-medium text-red-600">District Impact Unavailable</span>
+        </div>
+        <p className="text-gray-700 mb-4">
+          {error || 'Unable to generate district impact analysis at this time.'}
+        </p>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="px-3 py-2 bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+          >
+            Try Again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/legislation/components/DistrictSelector.tsx
+++ b/src/features/legislation/components/DistrictSelector.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * Copyright (c) 2019-2025 Mark Sandford
+ * Licensed under the MIT License. See LICENSE and NOTICE files.
+ */
+
+/**
+ * District Selector Widget
+ *
+ * Compact inline component for selecting a congressional district on bill pages.
+ * Reads from localStorage and URL params, allows manual entry.
+ */
+
+import React, { useState } from 'react';
+import { MapPin, X } from 'lucide-react';
+
+const STORAGE_KEY = 'civiq-district';
+
+interface DistrictSelectorProps {
+  currentDistrict: string | null;
+  onDistrictChange: (districtId: string | null) => void;
+  className?: string;
+}
+
+export function DistrictSelector({
+  currentDistrict,
+  onDistrictChange,
+  className = '',
+}: DistrictSelectorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [stateInput, setStateInput] = useState('');
+  const [districtInput, setDistrictInput] = useState('');
+  const [inputError, setInputError] = useState('');
+
+  const formatDistrictLabel = (districtId: string) => {
+    const parts = districtId.split('-');
+    if (parts.length === 2) {
+      const districtNum = parseInt(parts[1] || '0');
+      if (districtNum === 0) return `${parts[0]} (At-Large)`;
+      return `${parts[0]} District ${parts[1]}`;
+    }
+    return districtId;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setInputError('');
+
+    const state = stateInput.toUpperCase().trim();
+    const district = districtInput.trim();
+
+    if (!/^[A-Z]{2}$/.test(state)) {
+      setInputError('Enter a valid 2-letter state code (e.g., CA, NY)');
+      return;
+    }
+
+    if (!/^\d{1,2}$/.test(district)) {
+      setInputError('Enter a district number (0 for at-large)');
+      return;
+    }
+
+    const districtId = `${state}-${district}`;
+
+    try {
+      localStorage.setItem(STORAGE_KEY, districtId);
+    } catch {
+      // localStorage may be unavailable
+    }
+
+    onDistrictChange(districtId);
+    setIsEditing(false);
+    setStateInput('');
+    setDistrictInput('');
+  };
+
+  const handleClear = () => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // localStorage may be unavailable
+    }
+    onDistrictChange(null);
+  };
+
+  if (currentDistrict && !isEditing) {
+    return (
+      <div className={`flex items-center gap-3 p-3 bg-blue-50 border border-blue-200 ${className}`}>
+        <MapPin className="h-4 w-4 text-civiq-blue flex-shrink-0" />
+        <span className="text-sm text-gray-700">
+          Showing impact for{' '}
+          <span className="font-medium text-gray-900">{formatDistrictLabel(currentDistrict)}</span>
+        </span>
+        <button
+          onClick={() => setIsEditing(true)}
+          className="text-sm text-civiq-blue hover:text-blue-800 font-medium"
+        >
+          Change
+        </button>
+        <button
+          onClick={handleClear}
+          className="p-1 text-gray-400 hover:text-gray-600"
+          aria-label="Clear district"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+    );
+  }
+
+  if (isEditing || !currentDistrict) {
+    return (
+      <div className={`p-3 bg-gray-50 border border-gray-200 ${className}`}>
+        <div className="flex items-center gap-2 mb-2">
+          <MapPin className="h-4 w-4 text-gray-500" />
+          <span className="text-sm text-gray-700">
+            Enter your district to see how this bill affects your community
+          </span>
+        </div>
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={stateInput}
+            onChange={e => setStateInput(e.target.value)}
+            placeholder="State (CA)"
+            maxLength={2}
+            className="w-20 px-2 py-1 text-sm border-2 border-gray-300 focus:border-civiq-blue focus:outline-none"
+          />
+          <span className="text-gray-400">-</span>
+          <input
+            type="text"
+            value={districtInput}
+            onChange={e => setDistrictInput(e.target.value)}
+            placeholder="District (12)"
+            maxLength={2}
+            className="w-24 px-2 py-1 text-sm border-2 border-gray-300 focus:border-civiq-blue focus:outline-none"
+          />
+          <button
+            type="submit"
+            className="px-3 py-1 bg-civiq-blue text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            Go
+          </button>
+          {isEditing && currentDistrict && (
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="px-3 py-1 text-sm text-gray-600 hover:text-gray-800"
+            >
+              Cancel
+            </button>
+          )}
+        </form>
+        {inputError && <p className="text-xs text-red-600 mt-1">{inputError}</p>}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/features/legislation/services/ai/district-impact-analyzer.ts
+++ b/src/features/legislation/services/ai/district-impact-analyzer.ts
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2019-2025 Mark Sandford
+ * Licensed under the MIT License. See LICENSE and NOTICE files.
+ */
+
+/**
+ * District Impact Analyzer
+ *
+ * Cross-references bill summaries with district-level data to generate
+ * personalized impact analysis showing how legislation affects a specific district.
+ */
+
+import logger from '@/lib/logging/simple-logger';
+import { getRedisCache } from '@/lib/cache/redis-client';
+import { generateAIText } from '@/lib/ai/provider';
+import type { DistrictImpact } from '@/types/district-impact';
+import type { EconomicProfile, GovernmentServicesProfile } from '@/types/district-enhancements';
+
+interface BillMetadata {
+  billId: string;
+  title: string;
+  number: string;
+}
+
+interface DistrictData {
+  districtId: string;
+  economic: EconomicProfile;
+  government: GovernmentServicesProfile;
+}
+
+export class DistrictImpactAnalyzer {
+  private static readonly CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
+
+  /**
+   * Analyze how a bill impacts a specific district
+   */
+  static async analyzeImpact(
+    billSummary: string,
+    districtData: DistrictData,
+    billMetadata: BillMetadata
+  ): Promise<DistrictImpact> {
+    const cacheKey = `district-impact:${billMetadata.billId}:${districtData.districtId}`;
+
+    try {
+      // Check cache first
+      const cached = await getRedisCache().get<DistrictImpact>(cacheKey);
+      if (cached) {
+        logger.info('District impact cache hit', {
+          billId: billMetadata.billId,
+          districtId: districtData.districtId,
+          operation: 'district_impact_analysis',
+        });
+        return cached;
+      }
+
+      // Generate AI analysis
+      const impact = await this.generateAIAnalysis(billSummary, districtData, billMetadata);
+
+      // Cache the result
+      await getRedisCache().set(cacheKey, impact, this.CACHE_TTL);
+
+      logger.info('District impact analysis generated', {
+        billId: billMetadata.billId,
+        districtId: districtData.districtId,
+        overallImpact: impact.overallImpact,
+        confidence: impact.confidence,
+        operation: 'district_impact_analysis',
+      });
+
+      return impact;
+    } catch (error) {
+      logger.error('District impact analysis failed, using fallback', error as Error, {
+        billId: billMetadata.billId,
+        districtId: districtData.districtId,
+        operation: 'district_impact_analysis',
+      });
+
+      return this.generateFallbackAnalysis(districtData, billMetadata);
+    }
+  }
+
+  /**
+   * Generate AI-powered impact analysis
+   */
+  private static async generateAIAnalysis(
+    billSummary: string,
+    districtData: DistrictData,
+    billMetadata: BillMetadata
+  ): Promise<DistrictImpact> {
+    const systemPrompt = `You explain how federal legislation impacts specific congressional districts. You are nonpartisan, factual, and use plain language at an 8th grade reading level. You never editorialize. You ground your analysis in the district data provided.`;
+
+    const userPrompt = this.buildUserPrompt(billSummary, districtData, billMetadata);
+
+    const response = await generateAIText(systemPrompt, userPrompt, {
+      temperature: 0.3,
+      maxTokens: 1000,
+    });
+
+    return this.parseAIResponse(response, districtData, billMetadata);
+  }
+
+  /**
+   * Build the user prompt with bill summary and district data
+   */
+  private static buildUserPrompt(
+    billSummary: string,
+    districtData: DistrictData,
+    billMetadata: BillMetadata
+  ): string {
+    const { economic, government } = districtData;
+
+    return `
+BILL: ${billMetadata.number} - ${billMetadata.title}
+
+BILL SUMMARY:
+${billSummary}
+
+DISTRICT: ${districtData.districtId}
+
+DISTRICT ECONOMIC PROFILE:
+- Unemployment Rate: ${economic.employment.unemploymentRate}%
+- Labor Force Participation: ${economic.employment.laborForceParticipation}%
+- Average Wage: $${economic.employment.averageWage.toLocaleString()}
+- Major Industries: ${economic.employment.majorIndustries.join(', ') || 'Data unavailable'}
+- Broadband Availability: ${economic.infrastructure.broadbandAvailability}%
+- Fiber Availability: ${economic.connectivity.fiberAvailability}%
+- Average Download Speed: ${economic.connectivity.averageDownloadSpeed} Mbps
+
+DISTRICT FEDERAL SPENDING:
+- Total Annual Spending: $${government.federalInvestment.totalAnnualSpending.toLocaleString()}
+- Active Contracts/Grants: ${government.federalInvestment.contractsAndGrants}
+- Infrastructure Investment: $${government.federalInvestment.infrastructureInvestment.toLocaleString()}
+
+Analyze how this bill would impact district ${districtData.districtId}. Respond in JSON:
+{
+  "overallImpact": "High" | "Medium" | "Low" | "Uncertain",
+  "summary": "2-3 sentence personalized impact summary for this district",
+  "economicImpact": "How this bill affects the district economy",
+  "infrastructureImpact": "How this bill affects district infrastructure and broadband",
+  "affectedGroups": [
+    { "group": "Group name", "impact": "How they are affected", "scale": "Estimated number affected" }
+  ],
+  "relevantDistrictData": [
+    { "metric": "Metric name", "value": "Current value", "context": "How it compares nationally" }
+  ],
+  "confidence": 0.0-1.0
+}
+
+Rules:
+- Use plain language. Keep sentences under 20 words.
+- Be nonpartisan. State facts only.
+- Use the district data provided. Do not invent statistics.
+- If the bill has little connection to the district data, set overallImpact to "Uncertain" and explain why.
+- Include 2-4 affected groups and 2-4 relevant district data points.
+`;
+  }
+
+  /**
+   * Parse AI response into DistrictImpact format
+   */
+  private static parseAIResponse(
+    response: string,
+    districtData: DistrictData,
+    billMetadata: BillMetadata
+  ): DistrictImpact {
+    try {
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error('No JSON found in response');
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]);
+
+      return {
+        billId: billMetadata.billId,
+        districtId: districtData.districtId,
+        overallImpact: parsed.overallImpact || 'Uncertain',
+        summary: parsed.summary || '',
+        economicImpact: parsed.economicImpact || '',
+        infrastructureImpact: parsed.infrastructureImpact || '',
+        affectedGroups: parsed.affectedGroups || [],
+        relevantDistrictData: parsed.relevantDistrictData || [],
+        confidence: parsed.confidence || 0.7,
+        lastUpdated: new Date().toISOString(),
+        source: 'ai-generated',
+      };
+    } catch (error) {
+      throw new Error(`Failed to parse AI response: ${error}`);
+    }
+  }
+
+  /**
+   * Generate a template-based fallback when AI is unavailable
+   */
+  private static generateFallbackAnalysis(
+    districtData: DistrictData,
+    billMetadata: BillMetadata
+  ): DistrictImpact {
+    const { economic, government } = districtData;
+
+    const relevantDistrictData: DistrictImpact['relevantDistrictData'] = [];
+
+    if (economic.employment.unemploymentRate > 0) {
+      relevantDistrictData.push({
+        metric: 'Unemployment Rate',
+        value: `${economic.employment.unemploymentRate}%`,
+        context:
+          economic.employment.unemploymentRate > 5
+            ? 'Above national average'
+            : 'Near or below national average',
+      });
+    }
+
+    if (economic.connectivity.fiberAvailability > 0) {
+      relevantDistrictData.push({
+        metric: 'Broadband Access',
+        value: `${economic.connectivity.fiberAvailability}% fiber availability`,
+        context:
+          economic.connectivity.fiberAvailability < 50
+            ? 'Below national average'
+            : 'Near or above national average',
+      });
+    }
+
+    if (government.federalInvestment.totalAnnualSpending > 0) {
+      relevantDistrictData.push({
+        metric: 'Federal Spending',
+        value: `$${government.federalInvestment.totalAnnualSpending.toLocaleString()}`,
+        context: 'Total annual federal investment in the state',
+      });
+    }
+
+    return {
+      billId: billMetadata.billId,
+      districtId: districtData.districtId,
+      overallImpact: 'Uncertain',
+      summary: `This analysis shows available data for district ${districtData.districtId} in relation to ${billMetadata.number}. AI-powered impact analysis is temporarily unavailable.`,
+      economicImpact: `The district has an unemployment rate of ${economic.employment.unemploymentRate}% and an average wage of $${economic.employment.averageWage.toLocaleString()}.`,
+      infrastructureImpact: `The district has ${economic.connectivity.fiberAvailability}% fiber broadband availability and an average download speed of ${economic.connectivity.averageDownloadSpeed} Mbps.`,
+      affectedGroups: [],
+      relevantDistrictData,
+      confidence: 0.3,
+      lastUpdated: new Date().toISOString(),
+      source: 'fallback',
+    };
+  }
+}

--- a/src/types/district-impact.ts
+++ b/src/types/district-impact.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019-2025 Mark Sandford
+ * Licensed under the MIT License. See LICENSE and NOTICE files.
+ */
+
+export interface DistrictImpact {
+  billId: string;
+  districtId: string;
+  overallImpact: 'High' | 'Medium' | 'Low' | 'Uncertain';
+  summary: string;
+  economicImpact: string;
+  infrastructureImpact: string;
+  affectedGroups: Array<{
+    group: string;
+    impact: string;
+    scale: string;
+  }>;
+  relevantDistrictData: Array<{
+    metric: string;
+    value: string;
+    context: string;
+  }>;
+  confidence: number;
+  lastUpdated: string;
+  source: 'ai-generated' | 'fallback';
+}


### PR DESCRIPTION
## Summary
- Adds AI-powered district impact analysis that cross-references bill summaries with real district-level data (BLS employment, FCC broadband, USASpending.gov)
- Users can enter their congressional district to see how a specific bill affects their community
- Key differentiator for the Mozilla Democracy x AI grant application

## What's New
- **DistrictImpactAnalyzer** AI service with Redis caching (7-day TTL) and template fallback
- **API route** `/api/bill/[billId]/district-impact/[districtId]` — fetches bill summary + district data in parallel, returns personalized analysis
- **DistrictImpact component** with expandable sections: economic impact, infrastructure, affected groups, district data
- **DistrictSelector widget** with localStorage persistence and `?district=CA-12` URL param support
- **Integrated into bill page** after the AI summary section

## Test plan
- [ ] `npm run validate:all` passes (confirmed pre-push)
- [ ] Visit `/bill/119-hr-1?district=CA-12` — verify impact analysis loads
- [ ] Visit a bill page with no district — verify selector prompts for input
- [ ] Enter a district via the selector — verify it persists in localStorage on reload
- [ ] Test with invalid district (e.g., `ZZ-99`) — verify graceful error handling
- [ ] Disable AI (remove API key) — verify fallback template response works
- [ ] Second request to same bill+district — verify cached response is faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)