### PR TITLE
fix(intelligence): MR15+MR16 — restore vote-finance correlation for House reps

### DIFF
--- a/src/__tests__/intelligence/shared.test.ts
+++ b/src/__tests__/intelligence/shared.test.ts
@@ -225,6 +225,48 @@ describe('shared intelligence utilities', () => {
       const sectors = await getBillSectors('HR1234-119', 'Resolution on procedural matters');
       expect(sectors).toEqual([]);
     });
+
+    // ── MR15: subjects/policyArea classification context ────────────
+
+    it('feeds bill subjects + policyArea to the embedding classifier when provided', async () => {
+      mockGetSummary.mockResolvedValue(null);
+      mockClassifyBillSectors.mockResolvedValue([{ sector: 'DEFENSE', confidence: 0.8 }]);
+
+      const sectors = await getBillSectors('HR9999-119', 'Some bill', {
+        policyArea: 'Armed Forces and National Security',
+        subjects: ['Defense spending', 'Military procurement', 'Veterans benefits'],
+      });
+
+      expect(sectors).toEqual(['DEFENSE']);
+      // Classifier should see the subjects + policyArea + title joined, not just the title.
+      const passedText = mockClassifyBillSectors.mock.calls[0][0] as string;
+      expect(passedText).toContain('Defense spending');
+      expect(passedText).toContain('Military procurement');
+      expect(passedText).toContain('Armed Forces and National Security');
+      expect(passedText).toContain('Some bill');
+    });
+
+    it('uses policyArea to resolve sectors when the ML chain returns empty', async () => {
+      mockGetSummary.mockResolvedValue(null);
+      mockClassifyBillSectors.mockResolvedValue([]);
+      mockClassifyBillSectorsZeroShot.mockResolvedValue([]);
+
+      const sectors = await getBillSectors('HR8888-119', 'Procedural motion', {
+        policyArea: 'Health',
+      });
+
+      expect(sectors).toContain('HEALTH');
+    });
+
+    it('falls back to title-only behavior when no context is provided', async () => {
+      mockGetSummary.mockResolvedValue(null);
+      mockClassifyBillSectors.mockResolvedValue([{ sector: 'HEALTH', confidence: 0.9 }]);
+
+      await getBillSectors('HR7777-119', 'Medicare Act');
+
+      // Classifier text equals the title alone — no leading separators.
+      expect(mockClassifyBillSectors).toHaveBeenCalledWith('Medicare Act');
+    });
   });
 
   // ── inferSectorsFromTitle ───────────────────────────────────────

--- a/src/__tests__/intelligence/vote-finance-analyzer.test.ts
+++ b/src/__tests__/intelligence/vote-finance-analyzer.test.ts
@@ -214,7 +214,7 @@ describe('analyzeVoteFinance', () => {
 
     const setCalls = mockRedisSet.mock.calls;
     const insightCall = setCalls.find(
-      (call: unknown[]) => (call[0] as string) === 'insight:vote_finance:v3:P000197'
+      (call: unknown[]) => (call[0] as string) === 'insight:vote_finance:v4:P000197'
     );
     expect(insightCall).toBeDefined();
     expect(insightCall![2]).toBe(7 * 24 * 60 * 60);
@@ -241,7 +241,8 @@ describe('analyzeVoteFinance', () => {
   it('writes per-bill sector cache on first classify (MR2)', async () => {
     // BillSummaryCache misses force getBillSectors to fall through to the
     // embedding/keyword tiers, whose resolved result must land in Redis
-    // under `insight:bill_sectors:v1:{billId}`.
+    // under `insight:bill_sectors:v2:{billId}` (v2 introduced in MR15 when
+    // the classifier started consuming bill subjects + policyArea).
     mockGetSummary.mockResolvedValue(null);
     mockGetHouseMemberVotes.mockResolvedValue(makeVotes(3));
     mockGetSenateMemberVotes.mockResolvedValue([]);
@@ -249,7 +250,7 @@ describe('analyzeVoteFinance', () => {
     await analyzeVoteFinance('P000197');
 
     const sectorCacheWrite = mockRedisSet.mock.calls.find((call: unknown[]) =>
-      (call[0] as string).startsWith('insight:bill_sectors:v1:')
+      (call[0] as string).startsWith('insight:bill_sectors:v2:')
     );
     expect(sectorCacheWrite).toBeDefined();
     // 30-day TTL
@@ -264,7 +265,7 @@ describe('analyzeVoteFinance', () => {
     // pre-populated classification, so BillSummaryCache.getSummary must
     // NOT be consulted.
     mockRedisGet.mockImplementation(async (key: string) => {
-      if (key.startsWith('insight:bill_sectors:v1:')) return ['HEALTH'];
+      if (key.startsWith('insight:bill_sectors:v2:')) return ['HEALTH'];
       return null;
     });
 

--- a/src/app/api/representative/[bioguideId]/finance-jurisdiction/route.ts
+++ b/src/app/api/representative/[bioguideId]/finance-jurisdiction/route.ts
@@ -106,7 +106,7 @@ export async function GET(
           const contributions = await fecApiService.getSampleContributions(
             fecMapping.fecId,
             2024,
-            500
+            250
           );
 
           // Categorize each contribution by sector

--- a/src/features/representatives/services/batch-voting-service.ts
+++ b/src/features/representatives/services/batch-voting-service.ts
@@ -266,6 +266,10 @@ export interface StandardizedVote {
     number: string;
     title: string;
     url?: string;
+    /** Top-level policy area from Congress.gov (e.g., "Armed Forces and National Security"). */
+    policyArea?: string;
+    /** Fine-grained legislative subjects from Congress.gov (5–20 per bill, e.g., "Defense spending"). */
+    subjects?: string[];
   };
   totals: {
     yea: number;
@@ -1360,13 +1364,23 @@ export class BatchVotingService {
 
       const normalizedType = billTypeMap[billType.toUpperCase()] || billType.toLowerCase();
       const apiUrl = `https://api.congress.gov/v3/bill/119/${normalizedType}/${billNumber}?format=json`;
+      const subjectsUrl = `https://api.congress.gov/v3/bill/119/${normalizedType}/${billNumber}/subjects?format=json`;
 
-      const response = await httpClient.fetch(apiUrl, {
-        headers: {
-          'X-API-Key': this.apiKey,
-        },
-        signal: AbortSignal.timeout(2000), // Quick timeout for bill details
-      });
+      // Fire bill-detail and subjects in parallel — the subjects sub-resource
+      // gives 5–20 fine-grained tags ("Defense spending", "Health insurance")
+      // that drive bill-sector classification downstream (MR15).
+      const [response, subjectsResponse] = await Promise.all([
+        httpClient.fetch(apiUrl, {
+          headers: { 'X-API-Key': this.apiKey },
+          signal: AbortSignal.timeout(2000),
+        }),
+        httpClient
+          .fetch(subjectsUrl, {
+            headers: { 'X-API-Key': this.apiKey },
+            signal: AbortSignal.timeout(2000),
+          })
+          .catch(() => null),
+      ]);
 
       if (!response.ok) {
         logger.debug('Failed to fetch bill details', {
@@ -1400,6 +1414,33 @@ export class BatchVotingService {
       // Extract the title - Congress.gov provides it directly
       const title = billData.title || billData.shortTitle || `${billType} ${billNumber}`;
 
+      // policyArea is inline on the main bill response.
+      const policyAreaInline: string | undefined =
+        typeof billData.policyArea?.name === 'string' ? billData.policyArea.name : undefined;
+
+      // legislativeSubjects + policyArea (alt source) come from the subjects sub-resource.
+      let subjects: string[] | undefined;
+      let policyAreaFromSubjects: string | undefined;
+      if (subjectsResponse && subjectsResponse.ok) {
+        try {
+          const subjectsData = await subjectsResponse.json();
+          const list = subjectsData?.subjects?.legislativeSubjects;
+          if (Array.isArray(list) && list.length > 0) {
+            const names = list
+              .map((s: { name?: string }) => (typeof s?.name === 'string' ? s.name : null))
+              .filter((n): n is string => !!n);
+            if (names.length > 0) {
+              subjects = names;
+            }
+          }
+          if (typeof subjectsData?.subjects?.policyArea?.name === 'string') {
+            policyAreaFromSubjects = subjectsData.subjects.policyArea.name;
+          }
+        } catch {
+          // Subjects parse failure is non-fatal — bill still has title/policyArea.
+        }
+      }
+
       const bill: StandardizedVote['bill'] = {
         congress: 119,
         type: billType,
@@ -1408,6 +1449,10 @@ export class BatchVotingService {
         url:
           billUrl ||
           `https://www.congress.gov/bill/119th-congress/${normalizedType}-bill/${billNumber}`,
+        ...(policyAreaInline || policyAreaFromSubjects
+          ? { policyArea: policyAreaInline ?? policyAreaFromSubjects }
+          : {}),
+        ...(subjects ? { subjects } : {}),
       };
 
       // Cache the bill details for 24 hours

--- a/src/lib/fec/fec-api-service.ts
+++ b/src/lib/fec/fec-api-service.ts
@@ -724,9 +724,14 @@ export class FECApiService {
             const pageNonConduits = firstPage.results.filter(c => !isConduit(c));
             nonConduitContributions.push(...pageNonConduits);
 
-            // Determine how many more pages to fetch (max 4 more, cap at 500 total)
+            // Derive maxPages from the caller's requested count, not a hardcoded 5.
+            // Previously every call fetched up to 5 pages (500 raw contributions)
+            // regardless of `count`, which dominates cold-cache wall time for
+            // high-donor reps (MR16: Sherman was 25.8s on fetchContributions).
+            // Cap at 5 pages absolute to bound worst-case fan-out.
             const totalAvailable = firstPage.pagination?.count ?? firstPage.results.length;
-            const maxPages = Math.min(5, Math.ceil(totalAvailable / perPage));
+            const pagesForCount = Math.ceil(count / perPage);
+            const maxPages = Math.min(pagesForCount, 5, Math.ceil(totalAvailable / perPage));
             const needMore =
               nonConduitContributions.length < count &&
               firstPage.results.length >= perPage &&

--- a/src/lib/intelligence/analyzers/bill-intelligence-analyzer.ts
+++ b/src/lib/intelligence/analyzers/bill-intelligence-analyzer.ts
@@ -454,7 +454,7 @@ async function analyzeMemberSectorDonations(
     contributions = await fecApiService.getSampleContributions(
       fecId,
       getCurrentElectionCycle(),
-      500
+      250
     );
   } catch {
     return null;

--- a/src/lib/intelligence/analyzers/civic-brief-assembler.ts
+++ b/src/lib/intelligence/analyzers/civic-brief-assembler.ts
@@ -246,7 +246,7 @@ async function fetchFundingData(
   try {
     const [summary, contributions] = await Promise.all([
       fecApiService.getFinancialSummary(fecId, cycle).catch(() => null),
-      fecApiService.getSampleContributions(fecId, cycle, 500).catch(() => []),
+      fecApiService.getSampleContributions(fecId, cycle, 250).catch(() => []),
     ]);
 
     const totalRaised = summary?.receipts ?? summary?.total_receipts ?? null;

--- a/src/lib/intelligence/analyzers/finance-jurisdiction-analyzer.ts
+++ b/src/lib/intelligence/analyzers/finance-jurisdiction-analyzer.ts
@@ -273,7 +273,7 @@ async function fetchData(bioguideId: string): Promise<FetchResult> {
     contributions = await fecApiService.getSampleContributions(
       fecId,
       getCurrentElectionCycle(),
-      500
+      250
     );
   } catch {
     const unavailableReason = 'FEC contribution fetch failed';

--- a/src/lib/intelligence/analyzers/influence-chain-analyzer.ts
+++ b/src/lib/intelligence/analyzers/influence-chain-analyzer.ts
@@ -62,7 +62,7 @@ const CACHE_TTL = 7 * 24 * 60 * 60;
 const MAX_VOTES = 200;
 
 /** Max contributions to sample from FEC */
-const MAX_CONTRIBUTIONS = 500;
+const MAX_CONTRIBUTIONS = 250;
 
 /** Max chains to return */
 const MAX_CHAINS = 10;
@@ -224,6 +224,8 @@ interface RawVote {
   billNumber: string;
   billCongress: number;
   billTitle: string;
+  billPolicyArea?: string;
+  billSubjects?: string[];
   position: string;
   date: string;
 }
@@ -601,7 +603,10 @@ async function fetchAndClassifyVotes(
       const results = await Promise.all(
         batch.map(async vote => {
           const billId = `${vote.billType}${vote.billNumber}-${vote.billCongress}`;
-          const sectors = await getBillSectors(billId, vote.billTitle);
+          const sectors = await getBillSectors(billId, vote.billTitle, {
+            policyArea: vote.billPolicyArea,
+            subjects: vote.billSubjects,
+          });
           if (sectors.length === 0) return null;
           return { ...vote, billId, sectors };
         })
@@ -636,6 +641,8 @@ async function fetchVotes(bioguideId: string, chamber: 'House' | 'Senate'): Prom
           billNumber: String(v.bill?.number ?? ''),
           billCongress: v.bill?.congress ?? 0,
           billTitle: v.bill?.title ?? '',
+          billPolicyArea: v.bill?.policyArea,
+          billSubjects: v.bill?.subjects,
           position: v.position,
           date: v.date,
         }));

--- a/src/lib/intelligence/analyzers/pac-vote-analyzer.ts
+++ b/src/lib/intelligence/analyzers/pac-vote-analyzer.ts
@@ -356,7 +356,10 @@ async function processRecipientVotes(
     if (!vote.bill || (vote.position !== 'Yea' && vote.position !== 'Nay')) continue;
 
     const billId = `${vote.bill.type}${vote.bill.number}-${vote.bill.congress}`;
-    const sectors = await getBillSectors(billId, vote.bill.title);
+    const sectors = await getBillSectors(billId, vote.bill.title, {
+      policyArea: vote.bill.policyArea,
+      subjects: vote.bill.subjects,
+    });
 
     if (!sectors.includes(pacSector)) continue;
 

--- a/src/lib/intelligence/analyzers/shared.ts
+++ b/src/lib/intelligence/analyzers/shared.ts
@@ -290,7 +290,25 @@ export function findCommitteeMapping(committeeName: string): CommitteeMapping | 
  * version if the classifier itself changes in a breaking way.
  */
 const BILL_SECTORS_CACHE_TTL_S = 30 * 24 * 60 * 60;
-const BILL_SECTORS_CACHE_PREFIX = 'insight:bill_sectors:v1:';
+/**
+ * Cache key version. Bumped to v2 in MR15 because the classifier now sees
+ * bill subjects + policyArea text in addition to the title, so v1 entries
+ * (title-only classifications) would poison the new pipeline.
+ */
+const BILL_SECTORS_CACHE_PREFIX = 'insight:bill_sectors:v2:';
+
+/**
+ * Optional bill metadata that materially improves classification when present.
+ * Sourced from Congress.gov's `/v3/bill/{cong}/{type}/{num}/subjects` endpoint
+ * via `batchVotingService.fetchBillDetails`. When omitted, the classifier
+ * falls back to title-only behavior (MR15 Phase B).
+ */
+export interface BillClassificationContext {
+  /** Top-level policy area (e.g., "Armed Forces and National Security"). */
+  policyArea?: string;
+  /** Fine-grained legislative subjects (5–20 short phrases per bill). */
+  subjects?: string[];
+}
 
 /**
  * Get industry sectors for a bill. Four-tier fallback:
@@ -299,10 +317,14 @@ const BILL_SECTORS_CACHE_PREFIX = 'insight:bill_sectors:v1:';
  * 3. Zero-shot NLI classification (NLI model, understands natural language)
  * 4. Keyword-based inference (static, always works)
  *
- * The resolved result is memoized in Redis under `insight:bill_sectors:v1:{billId}`
+ * The resolved result is memoized in Redis under `insight:bill_sectors:v2:{billId}`
  * so the expensive classifier pipeline runs at most once per bill.
  */
-export async function getBillSectors(billId: string, billTitle: string): Promise<IndustrySector[]> {
+export async function getBillSectors(
+  billId: string,
+  billTitle: string,
+  context?: BillClassificationContext
+): Promise<IndustrySector[]> {
   const cacheKey = `${BILL_SECTORS_CACHE_PREFIX}${billId}`;
 
   try {
@@ -314,7 +336,7 @@ export async function getBillSectors(billId: string, billTitle: string): Promise
     // Cache miss or error — fall through and compute
   }
 
-  const sectors = await computeBillSectors(billId, billTitle);
+  const sectors = await computeBillSectors(billId, billTitle, context);
 
   try {
     await getRedisCache().set(cacheKey, sectors, BILL_SECTORS_CACHE_TTL_S);
@@ -325,7 +347,32 @@ export async function getBillSectors(billId: string, billTitle: string): Promise
   return sectors;
 }
 
-async function computeBillSectors(billId: string, billTitle: string): Promise<IndustrySector[]> {
+/**
+ * Build the text the classifier should see. Prefers Congress.gov's editorial
+ * subjects (5–20 short tags) over the bill title — titles are often only 4
+ * words long, which is noisy for embeddings/zero-shot. policyArea is also
+ * included as a strong top-level signal. Title is appended as a fallback
+ * signal regardless, so single-tag bills don't lose context.
+ */
+function buildClassificationText(billTitle: string, context?: BillClassificationContext): string {
+  const parts: string[] = [];
+  if (context?.subjects && context.subjects.length > 0) {
+    parts.push(context.subjects.join(', '));
+  }
+  if (context?.policyArea) {
+    parts.push(context.policyArea);
+  }
+  if (billTitle) {
+    parts.push(billTitle);
+  }
+  return parts.join('. ').trim();
+}
+
+async function computeBillSectors(
+  billId: string,
+  billTitle: string,
+  context?: BillClassificationContext
+): Promise<IndustrySector[]> {
   // Step 1: Cached AI summary
   try {
     const summary = await BillSummaryCache.getSummary(billId);
@@ -336,9 +383,11 @@ async function computeBillSectors(billId: string, billTitle: string): Promise<In
     // Cache miss — try embedding classifier
   }
 
+  const classifierText = buildClassificationText(billTitle, context);
+
   // Step 2: Semantic embedding classification
   try {
-    const embeddingResults = await classifyBillSectors(billTitle);
+    const embeddingResults = await classifyBillSectors(classifierText);
     if (embeddingResults.length > 0) {
       return embeddingResults.map(r => r.sector);
     }
@@ -348,7 +397,7 @@ async function computeBillSectors(billId: string, billTitle: string): Promise<In
 
   // Step 3: Zero-shot NLI classification
   try {
-    const zeroShotResults = await classifyBillSectorsZeroShot(billTitle);
+    const zeroShotResults = await classifyBillSectorsZeroShot(classifierText);
     if (zeroShotResults.length > 0) {
       return zeroShotResults.map(r => r.sector);
     }
@@ -356,8 +405,14 @@ async function computeBillSectors(billId: string, billTitle: string): Promise<In
     // Zero-shot failed — fall back to keywords
   }
 
-  // Step 4: Keyword-based inference
-  return inferSectorsFromTitle(billTitle);
+  // Step 4: Keyword-based inference. policyArea is the strongest signal here
+  // because it maps directly to the policy-area → sectors table, so prefer it
+  // when present; otherwise fall back to subjects + title text.
+  if (context?.policyArea) {
+    const fromPolicyArea = getIndustrySectorsForPolicyArea(context.policyArea);
+    if (fromPolicyArea.length > 0) return fromPolicyArea;
+  }
+  return inferSectorsFromTitle(classifierText || billTitle);
 }
 
 /**

--- a/src/lib/intelligence/analyzers/vote-finance-analyzer.ts
+++ b/src/lib/intelligence/analyzers/vote-finance-analyzer.ts
@@ -131,7 +131,10 @@ export async function analyzeVoteFinance(bioguideId: string): Promise<VoteFinanc
 export async function analyzeVoteFinanceWithReason(
   bioguideId: string
 ): Promise<VoteFinanceOutcome> {
-  const cacheKey = `insight:vote_finance:v3:${bioguideId}`;
+  // v4: bumped in MR15 because the classifier now sees bill subjects + policyArea,
+  // so v3-cached "insufficient-data" results would otherwise mask the new
+  // sector coverage and keep `overallCorrelation` stuck at null.
+  const cacheKey = `insight:vote_finance:v4:${bioguideId}`;
 
   // 1. Check cache
   try {
@@ -360,6 +363,8 @@ interface RawVote {
   billNumber: string;
   billCongress: number;
   billTitle: string;
+  billPolicyArea?: string;
+  billSubjects?: string[];
   position: string;
   date: string;
 }
@@ -379,6 +384,8 @@ async function fetchVotes(bioguideId: string, chamber: 'House' | 'Senate'): Prom
           billNumber: String(v.bill?.number ?? ''),
           billCongress: v.bill?.congress ?? 0,
           billTitle: v.bill?.title ?? '',
+          billPolicyArea: v.bill?.policyArea,
+          billSubjects: v.bill?.subjects,
           position: v.position,
           date: v.date,
         }));
@@ -394,7 +401,7 @@ async function fetchVotes(bioguideId: string, chamber: 'House' | 'Senate'): Prom
 
 async function fetchContributions(fecId: string) {
   try {
-    return await fecApiService.getSampleContributions(fecId, getCurrentElectionCycle(), 500);
+    return await fecApiService.getSampleContributions(fecId, getCurrentElectionCycle(), 250);
   } catch {
     return [];
   }
@@ -420,7 +427,10 @@ async function classifyVoteIndustries(rawVotes: RawVote[]): Promise<VoteWithIndu
       if (index >= rawVotes.length) return;
       const vote = rawVotes[index]!;
       const billId = `${vote.billType}${vote.billNumber}-${vote.billCongress}`;
-      const sectors = await getBillSectors(billId, vote.billTitle);
+      const sectors = await getBillSectors(billId, vote.billTitle, {
+        policyArea: vote.billPolicyArea,
+        subjects: vote.billSubjects,
+      });
       if (sectors.length === 0) continue;
       results.push({
         billId,

--- a/src/lib/intelligence/analyzers/vote-prediction-analyzer.ts
+++ b/src/lib/intelligence/analyzers/vote-prediction-analyzer.ts
@@ -318,7 +318,7 @@ async function fetchData(bioguideId: string, timer?: PhaseTimer): Promise<FetchR
       return v;
     }),
     fecApiService
-      .getSampleContributions(fecId, cycle, 500)
+      .getSampleContributions(fecId, cycle, 250)
       .catch(() => [])
       .then(c => {
         timer?.record('fetchContributions', performance.now() - contribStart, {
@@ -374,7 +374,10 @@ async function fetchData(bioguideId: string, timer?: PhaseTimer): Promise<FetchR
 
     let billSectors: IndustrySector[] = [];
     try {
-      billSectors = await getBillSectors(billId, billTitle);
+      billSectors = await getBillSectors(billId, billTitle, {
+        policyArea: v.bill?.policyArea,
+        subjects: v.bill?.subjects,
+      });
       if (billSectors.length > 0) votesWithSectors++;
     } catch {
       // Skip sector classification


### PR DESCRIPTION
## Summary

- **MR15**: Widen bill-sector classification to use Congress.gov subjects + policyArea metadata (not just bill title). Cache key bumped `insight:bill_sectors:v1` → `v2`, `insight:vote_finance:v3` → `v4`.
- **MR16**: Drop FEC `getSampleContributions` sample size from 500 → 250 at 6 high-throughput call sites; derive `maxPages` from caller's requested count so smaller samples no longer fetch 5 pages.

## Why

On the MR13 preview, House reps' vote-finance analyzer returned `overallCorrelation: null` because (a) the bill classification rate was ~15% (too few classified votes per sector to meet the 10-vote sample minimum) and (b) FEC contributions phase ate 25s of the 55s analyzer budget for $1M+ donor reps.

## Verified on preview (commit 998caed7, deployment civ-8pp270lhb-civdotiq.vercel.app)

- **S000344 (Sherman)**: `overallCorrelation: -0.20`, **6 sectors meet sample size** (was 2 / null before).
- **L000582 (Lieu)**: cold-cache wall time **10.0s**, `overallCorrelation: 0.3`, 6 sectors (was 0 / null).
- **Money-report ZIP 90049 → Sherman**: `voteFinance: { state: 'ready', value: -0.40 }`.
- Senate reps still `unavailable` due to the separate MR10 Akamai issue — not regressed, not in scope.

Phase B (procedural-vote classification) for MR15 and Phases B+C (cron pre-warm, TTL extension) for MR16 are **not needed** — Phase A of each alone hit success criteria.

## Test plan

- [x] `npm run validate:all` clean (0 errors, 153 pre-existing lint warnings)
- [x] All 1,694+ tests pass; new tests cover the subjects classification path
- [x] Preview deploy probes for S000344 + L000582 verified above
- [ ] Post-merge: confirm civdotiq.org Sherman money-report returns numeric correlation (production cache will cold-compute on first hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced bill classification with additional policy area and subjects metadata for more accurate sector determination across voting and financial analyses.

* **Improvements**
  * Optimized FEC contribution sampling size for faster financial analysis processing.

* **Tests**
  * Updated test coverage for context-aware bill sector classification and cache key versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/civdotiq/civ.iq/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->