### PR TITLE
fix(cache): route RedisCache.keys() through Upstash REST API

### DIFF
--- a/src/lib/cache/redis-client.ts
+++ b/src/lib/cache/redis-client.ts
@@ -626,13 +626,47 @@ export class RedisCache {
 
   async keys(pattern: string): Promise<string[]> {
     try {
+      // Upstash REST API — without this, /api/cache/invalidate silently
+      // returns 0 matches in production because this.client is null (REST
+      // mode skips ioredis entirely). Verified post-MR15/MR16 deploy: stale
+      // analyzer cache entries could not be flushed without this path.
+      if (
+        this.isConnected &&
+        !this.client &&
+        process.env.UPSTASH_REDIS_REST_URL &&
+        process.env.UPSTASH_REDIS_REST_TOKEN
+      ) {
+        try {
+          const response = await fetch(
+            `${process.env.UPSTASH_REDIS_REST_URL}/keys/${encodeURIComponent(pattern)}`,
+            {
+              headers: {
+                Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+              },
+            }
+          );
+
+          if (response.ok) {
+            const data = await response.json();
+            return Array.isArray(data.result) ? (data.result as string[]) : [];
+          }
+          throw new Error(`REST API failed: ${response.status}`);
+        } catch (restError) {
+          logger.warn('[Cache] REST API error on keys, falling back to memory', {
+            pattern,
+            error: (restError as Error).message,
+          });
+          // Fall through to memory cache
+        }
+      }
+
       if (this.isConnected && this.client) {
         return await this.client.keys(pattern);
-      } else {
-        // Search fallback cache
-        const regex = new RegExp(pattern.replace(/\*/g, '.*'));
-        return Array.from(this.fallbackCache.keys()).filter(key => regex.test(key));
       }
+
+      // Search fallback cache
+      const regex = new RegExp(pattern.replace(/\*/g, '.*'));
+      return Array.from(this.fallbackCache.keys()).filter(key => regex.test(key));
     } catch (error) {
       logger.error('Failed to get keys', error as Error, { pattern });
       return [];


### PR DESCRIPTION
## Summary

`RedisCache.keys(pattern)` only checked the ioredis client path, falling through to the in-memory fallback when `this.client === null`. In Upstash REST mode, `this.client` is intentionally null, so every pattern-based op silently bypassed real Redis and queried only the in-memory fallback.

## Why this matters

`/api/cache/invalidate` (and any other caller of `keys()`) reported 0 matches in production despite Upstash showing 3M+ stored commands. Discovered while trying to flush a stale `insight:vote_finance:v4:S000344` entry post-MR15/MR16 deploy.

Closes the audit gap from PROMPT-MR8 Step 4: "If any method silently assumes ioredis, it will break post-provisioning." All other methods (get/set/delete/exists/mget/flush) already had REST paths.

## Test plan

- [x] Type-check clean
- [x] No new tests added — pure REST-path addition mirroring the existing get/set/delete pattern
- [ ] Post-merge: hit \`/api/cache/invalidate\` with pattern \`insight:vote_finance:v4\`, confirm \`redisInvalidated > 0\`
- [ ] Then re-probe Sherman cold to confirm MR15+MR16 actually lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache key retrieval operations to properly support REST mode configurations with improved fallback mechanisms. The cache system now operates more reliably across different connection types and deployment scenarios. This update ensures consistent performance whether REST endpoints are available or alternative connection methods need to be utilized in various environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/civdotiq/civ.iq/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->