### PR TITLE
fix(vote-finance): raise MAX_VOTES 50 → 120 post-MR15/MR16

### DIFF
--- a/src/__tests__/intelligence/vote-finance-analyzer.test.ts
+++ b/src/__tests__/intelligence/vote-finance-analyzer.test.ts
@@ -157,8 +157,8 @@ describe('analyzeVoteFinance', () => {
     await analyzeVoteFinance('P000197');
 
     // Should call getHouseMemberVotes with sessions 1 and 2, trimmed cap (MR12)
-    expect(mockGetHouseMemberVotes).toHaveBeenCalledWith('P000197', 119, 1, 50);
-    expect(mockGetHouseMemberVotes).toHaveBeenCalledWith('P000197', 119, 2, 50);
+    expect(mockGetHouseMemberVotes).toHaveBeenCalledWith('P000197', 119, 1, 120);
+    expect(mockGetHouseMemberVotes).toHaveBeenCalledWith('P000197', 119, 2, 120);
   });
 
   it('classifies votes by sector', async () => {

--- a/src/lib/intelligence/analyzers/vote-finance-analyzer.ts
+++ b/src/lib/intelligence/analyzers/vote-finance-analyzer.ts
@@ -85,23 +85,19 @@ const CACHE_TTL = 7 * 24 * 60 * 60;
  * trimming just drops tail latency without meaningfully changing the
  * insight. Only applies here — other analyzers keep their own cap.
  */
-// MR12: 50 (was 120). With the JSON /members swap, each House vote costs two
-// sequential Congress.gov API calls (members + bill enrichment) gated through
-// a 5-concurrency limiter on the singleton BatchVotingService. Empirically
-// (preview probes 2026-05-14):
-//
-//   MAX_VOTES=120  cold ~108s    timeout (was already over budget pre-Akamai)
-//   MAX_VOTES=100  cold ~53s     timeout when 2+ /members fetches hit the
-//                                 httpClient retry tail (3× 10s + backoffs)
-//   MAX_VOTES=50   cold ~37s     status:'complete' for both probed reps
-//
-// 50 keeps total work near ~10s fetchVotes baseline, parallel with ~30s FEC
-// contributions, well under the 55s budget. Trade-off: each sector lands
-// below MIN_VOTES_PER_SECTOR=10 with this cap, so `overallCorrelation`
-// remains null until either (a) the httpClient retry policy is tightened so
-// MAX_VOTES can safely climb, or (b) the bill-classification rate (~12% of
-// raw House votes today) is widened. Both are tracked as MR12 follow-ups.
-const MAX_VOTES = 50;
+// Post-MR15/MR16 (2026-05-18): raised back to 120. The MR12-era 50 cap was
+// driven by two budget pressures that have since been resolved:
+//   - MR13 tightened the httpClient retry tail so individual /members fetches
+//     no longer burn 30s on retries.
+//   - MR16 cut FEC `getSampleContributions` cold path from ~25s → ~10s by
+//     dropping sample size 500 → 250 and deriving page count from count.
+//   - MR15 widened bill-sector classification from ~12% → ~30%, so each raw
+//     vote produces more usable sector signal.
+// Verified on preview deploy 998caed7 (Sherman, Lieu): MAX_VOTES=120 cold
+// compute finishes in 17-28s on production deploy 69b8a33e — well under the
+// 55s budget. Produces ~180 classified votes / 6 sectors meeting the
+// 10-vote sample floor for typical House reps (was 0-2 sectors at MAX_VOTES=50).
+const MAX_VOTES = 120;
 
 /** Standard disclaimer */
 const DISCLAIMER =


### PR DESCRIPTION
## Why this PR exists

After merging #65 (MR15+MR16), production showed Sherman/Lieu/Pelosi all returning \`overallCorrelation: null\` with ~25-68 classified votes — same as before MR15+MR16. Investigation revealed production's MAX_VOTES is 50 (set by b5cc9032 during MR12) while the preview branch had MAX_VOTES=120 (it diverged before b5cc9032).

MR15+MR16's lift only matters if there are enough raw votes to classify. With MAX_VOTES=50, even 100% classification can't produce 3 sectors with ≥10 votes each.

## Why 120 is safe now

The MR12 comment correctly noted MAX_VOTES=120 was over-budget then. Three subsequent fixes freed ~15s of cold-cache budget:

- **MR13**: tightened httpClient retry tail (no more 30s burns)
- **MR16**: dropped FEC sample 500 → 250 (25s → 10s cold)
- **MR15**: widened bill-sector classification (~12% → ~30%)

## Verified

Preview deploy \`998caed7\` (MAX_VOTES=120 + MR15+MR16) on production deploy \`69b8a33e\`:
- Sherman cold compute: 17s, 178 classified votes, 6 sectors, \`overallCorrelation: -0.40\` ✓
- Lieu cold compute: 10s, 6 sectors, \`overallCorrelation: 0.3\` ✓

Production (\`ada86c9d\`, MAX_VOTES=50, identical analyzer code):
- Sherman cold: 28s, 68 votes, 2 sectors, \`null\` ✗

## Test plan

- [x] \`vote-finance-analyzer.test.ts\` updated to expect \`120\`
- [x] All tests pass
- [ ] Post-merge: probe Sherman cold on production, expect numeric correlation matching preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)